### PR TITLE
Fix flake8 >= 5 regex failure

### DIFF
--- a/repo_helper.yml
+++ b/repo_helper.yml
@@ -45,7 +45,7 @@ extra_sphinx_extensions:
 
 entry_points:
   flake8.extension:
-   - SLOT=flake8_slots:Plugin
+   - SLO=flake8_slots:Plugin
 
 keywords:
  - flake8


### PR DESCRIPTION
Fix #32 - the reason for this is because `SLOT` does not match the regex `^[A-Z]{1,3}[0-9]{0,3}$` that is now present from `flake8` version 5 onwards.

`SLO` is used instead. Please let me know if another one is preferred. `flake8 --version` or `flake8 .` now works with this change.